### PR TITLE
API 2.0.0 Test

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: FastTransfer
 version: 1.0.2
-api: 1.12.0
+api: 2.0.0
 main: shoghicp\FastTransfer\FastTransfer
 load: STARTUP
 author: shoghicp


### PR DESCRIPTION
I am testing this Plugin now with API 2.0.0 and PHP7. If it isn't working i set it back to API 1.12.0.
